### PR TITLE
handle subscripts for functions and vars, eg. f_1(x) != f_2(x)

### DIFF
--- a/PS.g4
+++ b/PS.g4
@@ -21,7 +21,7 @@ R_BRACKET: ']';
 BAR: '|';
 
 FUNC_LIM:  '\\lim';
-LIM_APPROACH_SYM: '\\to' | '\\rightarrow' | '\\Rightarrow';
+LIM_APPROACH_SYM: '\\to' | '\\rightarrow' | '\\Rightarrow' | '\\longrightarrow' | '\\Longrightarrow';
 FUNC_INT:  '\\int';
 FUNC_SUM:  '\\sum';
 FUNC_PROD: '\\prod';
@@ -177,7 +177,7 @@ func:
     (subexpr? supexpr? | supexpr? subexpr?)
     (L_PAREN func_arg R_PAREN | func_arg_noparens)
 
-    | (LETTER | SYMBOL) // e.g. f(x)
+    | (LETTER | SYMBOL) subexpr? // e.g. f(x)
     L_PAREN arg=expr R_PAREN
 
     | FUNC_INT


### PR DESCRIPTION
Previously:
for functions... `proccess_sympy(f_1(x))` would return `f*x`, now it returns `f_{1}(x)`
for variables...`proccess_sympy(x_1+x_2)` would return `x+x`, now it returns `x_{1}+x_{2}`.

Also handles expressions in the subscripts, eg. `f_{2x+3}` is preserved.