### PR TITLE
transpose, multiple-argument functions, expressions in braces

### DIFF
--- a/PS.g4
+++ b/PS.g4
@@ -87,7 +87,7 @@ relation:
 equality:
     expr EQUAL expr;
 
-expr: additive;
+expr: '{'? WS*? additive WS*? '}'?;
 
 additive:
     additive (ADD | SUB) additive

--- a/PS.g4
+++ b/PS.g4
@@ -178,7 +178,7 @@ func:
     (L_PAREN func_arg R_PAREN | func_arg_noparens)
 
     | (LETTER | SYMBOL) subexpr? // e.g. f(x)
-    L_PAREN arg=expr R_PAREN
+    L_PAREN args R_PAREN
 
     | FUNC_INT
     (subexpr supexpr | supexpr subexpr)?
@@ -193,6 +193,8 @@ func:
     mp
     | FUNC_LIM limit_sub mp;
 
+args: (expr WS*? ',' WS*? args) | expr;
+
 limit_sub:
     UNDERSCORE L_BRACE
     (LETTER | SYMBOL)
@@ -200,7 +202,7 @@ limit_sub:
     expr (CARET L_BRACE (ADD | SUB) R_BRACE)?
     R_BRACE;
 
-func_arg: expr;
+func_arg: expr | (expr WS*? ',' WS*? func_arg);
 func_arg_noparens: mp_nofunc;
 
 subexpr: UNDERSCORE (atom | L_BRACE expr R_BRACE);

--- a/PS.g4
+++ b/PS.g4
@@ -87,7 +87,7 @@ relation:
 equality:
     expr EQUAL expr;
 
-expr: '{'? WS*? additive WS*? '}'?;
+expr: '{'? additive '}'?;
 
 additive:
     additive (ADD | SUB) additive
@@ -193,7 +193,7 @@ func:
     mp
     | FUNC_LIM limit_sub mp;
 
-args: (expr WS*? ',' WS*? args) | expr;
+args: (expr ',' args) | expr;
 
 limit_sub:
     UNDERSCORE L_BRACE
@@ -202,7 +202,7 @@ limit_sub:
     expr (CARET L_BRACE (ADD | SUB) R_BRACE)?
     R_BRACE;
 
-func_arg: expr | (expr WS*? ',' WS*? func_arg);
+func_arg: expr | (expr ',' func_arg);
 func_arg_noparens: mp_nofunc;
 
 subexpr: UNDERSCORE (atom | L_BRACE expr R_BRACE);

--- a/process_latex.py
+++ b/process_latex.py
@@ -213,7 +213,11 @@ def convert_exp(exp):
         if isinstance(base, list):
             raise Exception("Cannot raise derivative to power")
         if exp.atom():
-            exponent = convert_atom(exp.atom())
+            if exp.atom().LETTER():         # Transpose
+                if exp.atom().LETTER().getText() == 'T':
+                    return sympy.Function('T')(base)
+            else:
+                exponent = convert_atom(exp.atom())
         elif exp.expr():
             exponent = convert_expr(exp.expr())
         return sympy.Pow(base, exponent, evaluate=False)
@@ -370,8 +374,13 @@ def convert_func(func):
                 subscript = convert_atom(func.subexpr().atom())
             subscriptName = StrPrinter().doprint(subscript)
             fname += '_{' + subscriptName + '}'
-        arg = convert_expr(func.arg)
-        return sympy.Function(fname)(arg)
+        input_args = func.args()
+        output_args = []
+        while input_args.args():                        # handle multiple arguments to function
+            output_args.append(convert_expr(input_args.expr()))
+            input_args = input_args.args()
+        output_args.append(convert_expr(input_args.expr()))
+        return sympy.Function(fname)(*output_args)
     elif func.FUNC_INT():
         return handle_integral(func)
     elif func.FUNC_SQRT():


### PR DESCRIPTION
Transpose: previously `process_sympy(<expr>^T)` evaluates to `<expr>**T`, now `T(<expr>)`
Multi-argument functions: previously `f(a,b,c)` is not recognized, now it is
Expressions in braces: previously `{<expr>}` is not recognized, now it is the same as `<expr>`
