### PR TITLE
Added support for \left and \right

### DIFF
--- a/PS.g4
+++ b/PS.g4
@@ -11,8 +11,8 @@ SUB: '-';
 MUL: '*';
 DIV: '/';
 
-L_PAREN: '(';
-R_PAREN: ')';
+L_PAREN: '(' | '\\left';
+R_PAREN: ')' | '\\right';
 L_BRACE: '{';
 R_BRACE: '}';
 L_BRACKET: '[';

--- a/process_latex.py
+++ b/process_latex.py
@@ -513,6 +513,7 @@ def test_sympy():
     print process_sympy("\\int_{5x}^{2} x^2 dx")
     print process_sympy("\\int x^2 dx")
     print process_sympy("2 4 5 - 2 3 1")
+    print process_sympy("\\left x + 1 \\right *x")
 
 if __name__ == "__main__":
     test_sympy()


### PR DESCRIPTION
A small change to add support for the Latex alternatives to ( and ). This is useful if parsing mathematical expressions deriving from Latex.